### PR TITLE
zodの検証設定、admin/page.tsxの修正

### DIFF
--- a/next_app/src/app/admin/page.tsx
+++ b/next_app/src/app/admin/page.tsx
@@ -45,13 +45,12 @@ export default function Page() {
   };
 
   const handleTime = (hour: number, minute: number) => {
-    const time = new Date(
+    const time =
       //固定の年月日をつける,左に0をつけて2桁にする、日本時間にする
       `2000-01-01T${hour.toString().padStart(2, "0")}:${minute
         .toString()
-        .padStart(2, "0")}:00+09:00`,
-    ); // ISO8601形式の文字列に変換
-    setPromisedTime(time.toISOString());
+        .padStart(2, "0")}:00+09:00`;
+    setPromisedTime(time);
   };
 
   //登録ボタンを押すとユーザーデータが登録される

--- a/next_app/src/app/admin/page.tsx
+++ b/next_app/src/app/admin/page.tsx
@@ -9,6 +9,7 @@ import Header from "../../components/Header";
 import { FaUserCog, FaAngleRight, FaAngleLeft } from "react-icons/fa";
 import { userAgent } from "next/server";
 import convertTimeToHHMMFormat from "../../utils/convertTimeToHHMMFormat";
+import convertHMtoDatetime from "../../utils/convertHMtoDatetime";
 import { useTable, usePagination, Row } from "react-table";
 import DrumTimePicker from "../../components/DrumTimePicker";
 import Button from "../../components/Button";
@@ -45,11 +46,7 @@ export default function Page() {
   };
 
   const handleTime = (hour: number, minute: number) => {
-    const time =
-      //固定の年月日をつける,左に0をつけて2桁にする、日本時間にする
-      `2000-01-01T${hour.toString().padStart(2, "0")}:${minute
-        .toString()
-        .padStart(2, "0")}:00+09:00`;
+    const time = convertHMtoDatetime(hour, minute);
     setPromisedTime(time);
   };
 

--- a/next_app/src/app/page.tsx
+++ b/next_app/src/app/page.tsx
@@ -29,14 +29,10 @@ export default function Page() {
     },
   });
 
-  const handleAddUser = () => {
-    mutate({ name: "Carlie", promisedTime: "2021-01-01" });
-  };
 
   return (
     <>
       <Header title="HE研登校管理" icon={<FaHome size={30} />} />
-      <button onClick={handleAddUser}>add user</button>
       <div>isLoading: {isLoading ? "true" : "false"} </div>
       <ul>
         {data &&

--- a/next_app/src/schema/index.ts
+++ b/next_app/src/schema/index.ts
@@ -1,8 +1,15 @@
 import { z } from "zod";
 
-export { userSchema };
+//2000-01-01T10:30:00+09:00のような型（ISO8601拡張形式）を識別する正規表現
+const iso8601ExtendedRegex = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\+09:00$/;
+//4桁-2桁-2桁 T 2桁:2桁:2桁+09:00の形式
 
 const userSchema = z.object({
   name: z.string(),
-  promisedTime: z.coerce.date(),
+  //refineでZodスキーマにカスタムの検証ロジックを追加する
+  promisedTime: z.string().refine((value) => iso8601ExtendedRegex.test(value)),
+  //valueにはpromisedTimeの値が入る。.test(value)で正規表現にマッチするか判定
+  //text(value)がtrueならバリデーションをパス
 });
+
+export { userSchema };

--- a/next_app/src/utils/convertHMtoDatetime.tsx
+++ b/next_app/src/utils/convertHMtoDatetime.tsx
@@ -1,0 +1,9 @@
+const convertHMtoDatetime = (hour:number, minute:number) =>{
+    const time =
+    //固定の年月日をつける,左に0をつけて2桁にする、日本時間にする
+    `2000-01-01T${hour.toString().padStart(2, "0")}:${minute
+      .toString()
+      .padStart(2, "0")}:00+09:00`;
+    return time;
+}
+export default convertHMtoDatetime;


### PR DESCRIPTION
## やったこと

### zodの検証設定
* promisedTimeは2000-01-01T10:30:00+09:00のような型のみを許すようにsrc/schema/index.tsにあるzodの設定を変更した

### adminページの修正
* 管理者ページからユーザー情報を登録するときにpromisedTimeが2000-01-01T10:30:00+09:00のような型になるよう、admin/page.tsxのhandleTimeを変更した


## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* postmanで"2000-01-01T10:30:00","01/01/2000 10:30","Sat, 1 Jan 2000 10:30:00 +0900"など"2000-01-01T10:30:00+09:00"の型以外のものをpromisedTimeとして追加し、エラーが出ることを確認した。"2000-01-01T10:30:00+09:00"の型のときはデータベースに登録されることを確認した。
* adminページからユーザーを登録し、データベースに登録されることを確認した。
