### PR TITLE
公欠登録機能作成、バリテーション設定

### DIFF
--- a/next_app/src/app/api/absence/route.ts
+++ b/next_app/src/app/api/absence/route.ts
@@ -1,0 +1,26 @@
+import prisma from "../../../lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+import { absenceSchema, validateAbsence } from "@/schema";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  try {
+    await absenceSchema.parseAsync(body);
+
+    const isValidAbsence = await validateAbsence(body.userId, body.absenceTime);
+    if (!isValidAbsence) {
+      return NextResponse.json({
+        ok: false,
+        error: "登録済みの公欠です",
+      });
+    }
+    await prisma.absence.create({
+      data: body,
+    });
+    return NextResponse.json({
+      ok: true,
+    });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error });
+  }
+}


### PR DESCRIPTION
## やったこと

### 公欠をPOSTするバックエンドを作成した
* next_app/src/app/api/absence/route.tsにユーザーID、公欠理由、公欠日をデータベースに登録するPOST関数を作成した
### 公欠をPOSTするときのバリテーションを設定した
* next_app/src/schema/index.tsに作成した
* 存在しないユーザーIDを指定した場合、エラーが出るようにした
* 同じユーザーが同じ日付で公欠を登録した場合、エラーが出るようにした

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 公欠を登録できるようになる

## できなくなること（ユーザ目線）

* 無し

## 動作確認

### postmanで公欠をPOSTした
* 存在するユーザーが登録していない日付でPOSTするとデータベースに公欠が登録された
*  存在しないユーザーがPOSTするとエラーになった
* 存在するユーザーがすでに登録している日付でPOSTするとエラーになった

