### PR TITLE
22 hamburger

### DIFF
--- a/next_app/package.json
+++ b/next_app/package.json
@@ -23,6 +23,7 @@
     "eslint-config-next": "13.4.9",
     "next": "14.0.3",
     "postcss": "8.4.25",
+    "postcss-nesting": "^12.0.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.12.0",

--- a/next_app/postcss.config.js
+++ b/next_app/postcss.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   plugins: {
+    'postcss-nesting': {}, // プラグイン名をキーとして使用
     tailwindcss: {},
     autoprefixer: {},
   },
 };
+

--- a/next_app/src/app/absence/[userId]/page.tsx
+++ b/next_app/src/app/absence/[userId]/page.tsx
@@ -3,7 +3,7 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 import React from "react";
 import Header from "../../../components/Header";
-import { FaHome } from "react-icons/fa";
+import { FaBed } from "react-icons/fa";
 
 const Page = ({ params }: { params: { userId: string } }) => {
   const userId = params.userId;
@@ -14,7 +14,7 @@ const Page = ({ params }: { params: { userId: string } }) => {
 
   return (
     <div>
-      <Header title="HE研登校管理" icon={<FaHome size={30} />}  userId={userId} />
+      <Header title="公欠の登録" icon={<FaBed size={30} />} userId={userId} />
       <h1>id: {userId}</h1>
     </div>
   );

--- a/next_app/src/app/change-time/[userId]/page.tsx
+++ b/next_app/src/app/change-time/[userId]/page.tsx
@@ -3,7 +3,7 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 import React from "react";
 import Header from "../../../components/Header";
-import { FaHome } from "react-icons/fa";
+import { FaRegCalendarAlt } from "react-icons/fa";
 
 const Page = ({ params }: { params: { userId: string } }) => {
   const userId = params.userId;
@@ -14,7 +14,7 @@ const Page = ({ params }: { params: { userId: string } }) => {
 
   return (
     <div>
-      <Header title="HE研登校管理" icon={<FaHome size={30} />}  userId={userId} />
+      <Header title="目標の変更" icon={<FaRegCalendarAlt size={30} />} userId={userId} />
       <h1>id: {userId}</h1>
     </div>
   );

--- a/next_app/src/app/globals.css
+++ b/next_app/src/app/globals.css
@@ -9,8 +9,9 @@
   --background-end-rgb: 255, 255, 255;
   --dark-mode-bg-color: #000000; /* ダークモード時の背景色 */
   --dark-mode-border-color: #ffffff; /* ダークモード時の枠線色 */
-  --menu-background-color-dark: #000000; /* Black background for the menu */
-  --button-border-color-dark: #ffffff; /* White border for buttons */
+  --menu-background-color-dark: #000000; 
+  --button-border-color-dark: #ffffff; 
+  --border-color-light: #000000; /* ライトモード時のボーダーカラー (黒) */
 }
 
 body {
@@ -25,6 +26,12 @@ textarea {
   font-family: "Noto Sans JP", sans-serif;
 }
 
+@media (prefers-color-scheme: light) {
+  body {
+    --border-color: var(--border-color-light);
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --foreground-rgb: 255, 255, 255; /* ダークモード時のフォアグラウンドカラー（白） */
@@ -33,6 +40,7 @@ textarea {
     --input-text-color: #ffffff; /* ダークモード時の入力フィールドのテキストカラー */
     --foreground-rgb: 255, 255, 255;
     --background-color: #000000;
+    
   }
 
   body {

--- a/next_app/src/app/globals.css
+++ b/next_app/src/app/globals.css
@@ -7,6 +7,10 @@
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
+  --dark-mode-bg-color: #000000; /* ダークモード時の背景色 */
+  --dark-mode-border-color: #ffffff; /* ダークモード時の枠線色 */
+  --menu-background-color-dark: #000000; /* Black background for the menu */
+  --button-border-color-dark: #ffffff; /* White border for buttons */
 }
 
 body {
@@ -27,6 +31,8 @@ textarea {
     --background-color: #000000; /* ダークモード時の背景色（黒） */
     --input-background-color: #000000; /* ダークモード時の入力フィールドの背景色 */
     --input-text-color: #ffffff; /* ダークモード時の入力フィールドのテキストカラー */
+    --foreground-rgb: 255, 255, 255;
+    --background-color: #000000;
   }
 
   body {
@@ -43,4 +49,14 @@ textarea {
       --input-text-color
     ); /* ダークモード時の入力フィールドの境界線のカラーを適用 */
   }
+
+  .dark-mode-bg {
+    background-color: var(--dark-mode-bg-color);
+  }
+
+  .dark-mode-border {
+    border-color: var(--dark-mode-border-color);
+  }
 }
+
+

--- a/next_app/src/app/test/hamburger-menu/page.tsx
+++ b/next_app/src/app/test/hamburger-menu/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { User } from "@prisma/client";
+import axios from "axios";
+import { useQuery } from "@tanstack/react-query";
+import Header from "../../../components/Header";
+import { FaHome } from "react-icons/fa";
+import { useState } from "react";
+import Button from "../../../components/Button";
+import { useRouter } from "next/navigation";
+import CustomLinearProgress from "../../../components/CustomLinearProgress";
+
+export default function Page() {
+  const router = useRouter();
+  // FIX: たまにisLoadingがtrueのままになってしまう
+  const { data, isLoading, error } = useQuery<User[]>({
+    queryKey: ["users"],
+    queryFn: async () => {
+      const { data } = await axios.get("/api/users");
+      console.log(data);
+      return data;
+    },
+  });
+
+  const [selectedName, setSelectedName] = useState<string>("");
+  const [isDisabled, setIsDisabled] = useState<boolean>(true);
+
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === "") {
+      setIsDisabled(true);
+    } else {
+      setIsDisabled(false);
+      setSelectedName(e.target.value);
+    }
+  };
+
+  const handleClick = () => {
+    if (isLoading || !data) {
+      return;
+    }
+    const selectedUser = data.find((user) => user.name === selectedName);
+
+    if (selectedUser) {
+      const url = `/attend/${selectedUser.id}`;
+      router.push(url);
+    }
+  };
+
+  return (
+    <>
+      <Header title="HE研登校管理" icon={<FaHome size={30} />} />
+      {isLoading ? <CustomLinearProgress /> : <div></div>}
+      {error ? (
+        <div>エラーが発生しました： {error.message}</div>
+      ) : (
+        <div>
+          <div className="flex justify-center pt-8 pb-2 font-bold">
+            ユーザー選択（全{data ? data.length : " "}名）
+          </div>
+          <label className="flex justify-center">
+            <select
+              value={selectedName}
+              onChange={handleSelect}
+              className="w-32 px-2 py-2 rounded-md block appearance-none bg-white border border-gray-900 text-black"
+            >
+              {/* 初期オプション */}
+              <option value=""></option>
+              {/* data から取得した名前をオプションとしてマップ */}
+              {data &&
+                data.map((user) => (
+                  <option key={user.id} value={user.name} className="text-black">
+                    {user.name}
+                  </option>
+                ))}
+            </select>
+            <Button
+              onClick={handleClick}
+              isDisabled={isDisabled}
+              color="primary"
+              className="flex justify-center"
+            >
+              決定
+            </Button>
+          </label>
+        </div>
+      )}
+    </>
+  );
+}

--- a/next_app/src/components/HamburgerButton.tsx
+++ b/next_app/src/components/HamburgerButton.tsx
@@ -1,0 +1,7 @@
+import React, { useState } from "react";
+import { FaBars } from "react-icons/fa";
+
+const HamburgerButton = () => {
+}
+
+export default HamburgerButton;

--- a/next_app/src/components/HamburgerButton.tsx
+++ b/next_app/src/components/HamburgerButton.tsx
@@ -1,7 +1,28 @@
 import React, { useState } from "react";
-import { FaBars } from "react-icons/fa";
 
-const HamburgerButton = () => {
-}
+type HamburgerButtonProps = {
+  icon: React.ReactNode;
+  title: string;
+  toggleEvent: () => void;
+};
+
+const HamburgerButton = ({ icon, title, toggleEvent }: HamburgerButtonProps) => {
+  return (
+    <div className="flex justify-center items-center h-full w-full">
+      <button
+        onClick={toggleEvent}
+        className={`flex items-center w-full hover:bg-gray-300 ${
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "border-white"
+            : "border-black"
+        }`}
+        style={{ height: "75px" }}
+      >
+        <div className="ml-8 mr-8">{icon}</div>
+        <div className="text-xl">{title}</div>
+      </button>
+    </div>
+  );
+};
 
 export default HamburgerButton;

--- a/next_app/src/components/HamburgerMenu.tsx
+++ b/next_app/src/components/HamburgerMenu.tsx
@@ -1,0 +1,11 @@
+import React, { useState } from "react";
+import HamburgerButton from "./HamburgerButton";
+import { FaBars } from "react-icons/fa";
+
+const HamburgerMenu = () => {
+return (
+ 
+)
+}
+
+export default HamburgerMenu;

--- a/next_app/src/components/HamburgerMenu.tsx
+++ b/next_app/src/components/HamburgerMenu.tsx
@@ -63,14 +63,14 @@ const HamburgerMenu = ({ closeMenu, userId }: HamburgerMenuProps) => {
       </div>
       {userId && ( //admin,welcomeページでは表示しない
         <>
-          <div className="border-t-2">
+          <div className="border-t-2" style={{ borderColor: "var(--border-color)" }}>
             <HamburgerButton
               icon={<FaBed size={40} />}
               title="公欠の登録"
               toggleEvent={redirectAbsent}
             />
           </div>
-          <div className="border-t-2">
+          <div className="border-t-2" style={{ borderColor: "var(--border-color)" }}>
             <HamburgerButton
               icon={<FaRegCalendarAlt size={40} />}
               title="登校目標時刻の変更"
@@ -79,7 +79,7 @@ const HamburgerMenu = ({ closeMenu, userId }: HamburgerMenuProps) => {
           </div>
         </>
       )}
-      <div className="border-t-2 border-b-2">
+      <div className="border-t-2 border-b-2 " style={{ borderColor: "var(--border-color)" }}>
         <HamburgerButton
           icon={<FaGithub size={40} />}
           title="開発に参加しよう"

--- a/next_app/src/components/HamburgerMenu.tsx
+++ b/next_app/src/components/HamburgerMenu.tsx
@@ -65,6 +65,13 @@ const HamburgerMenu = ({ closeMenu, userId }: HamburgerMenuProps) => {
         <>
           <div className="border-t-2" style={{ borderColor: "var(--border-color)" }}>
             <HamburgerButton
+              icon={<FaHome size={40} />}
+              title="登校を登録する"
+              toggleEvent={redirectHome}
+            />
+          </div>
+          <div className="border-t-2" style={{ borderColor: "var(--border-color)" }}>
+            <HamburgerButton
               icon={<FaBed size={40} />}
               title="公欠の登録"
               toggleEvent={redirectAbsent}
@@ -86,17 +93,6 @@ const HamburgerMenu = ({ closeMenu, userId }: HamburgerMenuProps) => {
           toggleEvent={redirectGit}
         />
       </div>
-      {userId && ( //admin,welcomeページでは表示しない
-        <footer className="absolute bottom-0 right-0 p-2">
-          <div>
-            <HamburgerButton
-              icon={<FaHome size={30} />}
-              title="ホームに戻る"
-              toggleEvent={redirectHome}
-            />
-          </div>
-        </footer>
-      )}
     </div>
   );
 };

--- a/next_app/src/components/HamburgerMenu.tsx
+++ b/next_app/src/components/HamburgerMenu.tsx
@@ -1,11 +1,104 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import HamburgerButton from "./HamburgerButton";
-import { FaBars } from "react-icons/fa";
+import { FaBed, FaRegCalendarAlt, FaGithub, FaHome, FaTimes } from "react-icons/fa";
+import { useRouter } from "next/navigation";
 
-const HamburgerMenu = () => {
-return (
- 
-)
-}
+type HamburgerMenuProps = {
+  closeMenu: () => void;
+  userId?: string;
+};
+
+const HamburgerMenu = ({ closeMenu, userId }: HamburgerMenuProps) => {
+  const router = useRouter();
+  // 閉じるときと開けるときでアニメーションを逆転
+  const [isClosing, setIsClosing] = useState(false);
+  const handleMenuClose = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      closeMenu();
+    }, 300);
+  };
+
+  const redirectAbsent = () => {
+    if (userId) {
+      handleMenuClose();
+      router.push(`/absence/${userId}`);
+    }
+  };
+
+  const redirectPromisedTime = () => {
+    if (userId) {
+      handleMenuClose();
+      router.push(`/change-time/${userId}`);
+    }
+  };
+  const redirectGit = () => {
+    if (userId) {
+      handleMenuClose();
+      router.push(`https://github.com/oXyut/check-attendance-docker`);
+    }
+  };
+  const redirectHome = () => {
+    if (userId) {
+      handleMenuClose(); // メニューを閉じる
+      router.push(`/attend/${userId}`);
+    }
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 ${
+        isClosing ? "animate-slideOut" : "animate-slideIn"
+      } flex flex-col min-h-screen ${
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "bg-black border-white"
+          : "bg-white border-black"
+      }`}
+    >
+      <div className="justify-center flex items-center" style={{ height: "75px" }}>
+        <div className="text-2xl ml-16 mr-16">メニュー</div>
+        <button onClick={handleMenuClose}>
+          <FaTimes size={30} />
+        </button>
+      </div>
+      {userId && ( //admin,welcomeページでは表示しない
+        <>
+          <div className="border-t-2">
+            <HamburgerButton
+              icon={<FaBed size={40} />}
+              title="公欠の登録"
+              toggleEvent={redirectAbsent}
+            />
+          </div>
+          <div className="border-t-2">
+            <HamburgerButton
+              icon={<FaRegCalendarAlt size={40} />}
+              title="登校目標時刻の変更"
+              toggleEvent={redirectPromisedTime}
+            />
+          </div>
+        </>
+      )}
+      <div className="border-t-2 border-b-2">
+        <HamburgerButton
+          icon={<FaGithub size={40} />}
+          title="開発に参加しよう"
+          toggleEvent={redirectGit}
+        />
+      </div>
+      {userId && ( //admin,welcomeページでは表示しない
+        <footer className="absolute bottom-0 right-0 p-2">
+          <div>
+            <HamburgerButton
+              icon={<FaHome size={30} />}
+              title="ホームに戻る"
+              toggleEvent={redirectHome}
+            />
+          </div>
+        </footer>
+      )}
+    </div>
+  );
+};
 
 export default HamburgerMenu;

--- a/next_app/src/components/HamburgerMenu.tsx
+++ b/next_app/src/components/HamburgerMenu.tsx
@@ -66,7 +66,7 @@ const HamburgerMenu = ({ closeMenu, userId }: HamburgerMenuProps) => {
           <div className="border-t-2" style={{ borderColor: "var(--border-color)" }}>
             <HamburgerButton
               icon={<FaHome size={40} />}
-              title="登校を登録する"
+              title="登校を記録"
               toggleEvent={redirectHome}
             />
           </div>

--- a/next_app/src/components/Header.tsx
+++ b/next_app/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { FaBars } from "react-icons/fa";
+import HamburgerMenu from "./HamburgerMenu";
 
 type HeaderProps = {
   title: string;
@@ -7,7 +8,9 @@ type HeaderProps = {
 };
 
 const Header = ({ title, icon }: HeaderProps) => {
-  const toggleMenu = () => {};
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleMenu = () => {HamburgerMenu};
+  
 
   return (
     <header className="pt-2">

--- a/next_app/src/components/Header.tsx
+++ b/next_app/src/components/Header.tsx
@@ -5,12 +5,14 @@ import HamburgerMenu from "./HamburgerMenu";
 type HeaderProps = {
   title: string;
   icon: React.ReactNode;
+  userId?: string;
 };
 
-const Header = ({ title, icon }: HeaderProps) => {
+const Header = ({ title, icon, userId }: HeaderProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const toggleMenu = () => {HamburgerMenu};
-  
+  const toggleMenu = () => {
+    setIsOpen(!isOpen);
+  };
 
   return (
     <header className="pt-2">
@@ -21,6 +23,7 @@ const Header = ({ title, icon }: HeaderProps) => {
           <FaBars size={25} />
         </button>
       </nav>
+      {isOpen && <HamburgerMenu closeMenu={toggleMenu} userId={userId} />}
     </header>
   );
 };

--- a/next_app/tailwind.config.js
+++ b/next_app/tailwind.config.js
@@ -16,6 +16,24 @@ module.exports = {
         secondary: "#FF4858",
       },
     },
+
+    // slideInとslideOutという名前のスライドアニメーションを定義
+    extend: {
+      keyframes: {
+        slideIn: {
+          "0%": { transform: "translateX(100%)" }, //開始時は右端から
+          "100%": { transform: "translateX(0)" }, //終了時は左端まで移動
+        },
+        slideOut: {
+          "0%": { transform: "translateX(0)" }, //開始時は左端から
+          "100%": { transform: "translateX(100%)" }, //終了時は右端まで移動
+        },
+      },
+      animation: {
+        slideIn: "slideIn 0.3s ease-out forwards",
+        slideOut: "slideOut 0.3s ease-out forwards",
+      },
+    },
   },
   plugins: [],
   important: true,

--- a/next_app/yarn.lock
+++ b/next_app/yarn.lock
@@ -19,6 +19,11 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@csstools/selector-specificity@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.1.tgz#d84597fbc0f897240c12fc0a31e492b036c70e40"
+  integrity sha512-NPljRHkq4a14YzZ3YD406uaxh7s0g6eAq3L9aLOWywoqe8PkYamAvtsh7KNX6c++ihDrJ0RiU+/z7rGnhlZ5ww==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -2078,10 +2083,26 @@ postcss-nested@^6.0.1:
   dependencies:
     postcss-selector-parser "^6.0.11"
 
+postcss-nesting@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-12.0.2.tgz#cb92061347db3e7c38c174c97cb01feff2eef439"
+  integrity sha512-63PpJHSeNs93S3ZUIyi+7kKx4JqOIEJ6QYtG3x+0qA4J03+4n0iwsyA1GAHyWxsHYljQS4/4ZK1o2sMi70b5wQ==
+  dependencies:
+    "@csstools/selector-specificity" "^3.0.1"
+    postcss-selector-parser "^6.0.13"
+
 postcss-selector-parser@^6.0.11:
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
   integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-selector-parser@^6.0.13:
+  version "6.0.15"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz#11cc2b21eebc0b99ea374ffb9887174855a01535"
+  integrity sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"


### PR DESCRIPTION
## やったこと

### Headerコンポーネントの修正
* ハンバーガーボタンを押すとハンバーガーメニューが表示されるようにした
* ユーザーIDをHamburgerMenuコンポーネントに渡すようにした

### HamburgerMenuコンポーネントの作成
- ヘッダーのハンバーガーボタンを押すとハンバーガーメニューがスライドのアニメーションで現れ、×ボタンを押すとスライドアニメーションで消えるようにした。アニメーションはnext_app/tailwind.config.jsで定義した。
-  公欠の登録、登校目標時刻の変更、開発に参加しよう、ホームに戻るボタンをHamburgerButtonコンポーネントを使って作成した
    - 「公欠の登録」
        - /absence/[userId]/page.tsxに遷移
        - admin,weloceページでは表示されないようにした
    - 「登校目標時刻の変更」
        - /change-time/[userId]/page.tsxに遷移
        -  admin,weloceページでは表示されないようにした
    - 「開発に参加しよう」 
        - https://github.com/oXyut/check-attendance-dockerに遷移
    -  「ホームに戻る」
         - /attend/[userId]/page.tsxに遷移
         - 画面右下にフッターのように配置した
         - admin,weloceページでは表示されないようにした
         
### HamburgerButtonコンポーネントの作成
- HamburgerMenuコンポーネントで使用するボタンを作成した。押すとボタンの色が灰色になるようにした。

### ハンバーガーメニューから遷移するページの作成
- /absence/[userId]/page.tsx, /change-time/[userId]/page.tsx,  /attend/[userId]/page.tsxを作成した
- ユーザーのIDがプリントされるようにした

## やらないこと

なし

## できるようになること（ユーザ目線）

* ハンバーガーメニューが使えるようになり、他のページに遷移できるようになる

## できなくなること（ユーザ目線）

* なし

## 動作確認

- welcomeページでユーザーを選択してattend/[userId]/page.tsxページに飛んだ後にハンバーガーメニューを開いた
  - スライドのアニメーションでハンバーガーメニューが表示され、×ボタンをおすとスライドのアニメーションで消えた
  - 公欠の登録、登校目標時刻の変更、ホームに戻るボタンを押すとそのユーザーのそれぞれのページに遷移した
  - 遷移した先のページでハンバーガーメニューを開き、公欠の登録、登校目標時刻の変更、ホームに戻るボタンを押したところさらにそれぞれのページに遷移した
  - 開発に参加しようボタンを押したところhttps://github.com/oXyut/check-attendance-dockerに遷移した

* welcomeページ、adminページでハンバーガーメニューを押したところ、開発に参加しようボタンのみが現れた。

## その他
* ボタンを押した後の遷移先のページ名がissueのものと異なるものになりました