### PR TITLE
attendのバックエンドの修正

### DIFF
--- a/next_app/src/schema/index.ts
+++ b/next_app/src/schema/index.ts
@@ -52,7 +52,8 @@ const changeTimeSchema = z.object({
 export { changeTimeSchema };
 
 const attendanceTimeSchema = z.object({
-  id: z.string(),
   attendanceTime: z.string(),
 });
 export { attendanceTimeSchema };
+
+


### PR DESCRIPTION
## やったこと

### POSTの修正
* Attendanceテーブルに登録されるレーベルが、同じユーザーでも新規作成されるようにした
* Attendanceテーブルのidは新たに作成され、userIdはuserテーブルのidが入るようにした
* 同じユーザーの同じ日にPOSTを飛ばした場合、はじいてdbに登録しないようにした
### GETの修正
* GETのresponseのattendanceTimeは8:30のような形でなく、2024-01-01T03:00:40.198ZのようなAttendanceテーブルのattendanceTimeと同じものが返されるようにした。
* isAttendがfalseのときのattendanceTimeは1990-01-01T00:00:00.000Zとした
## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

### postmanでPOSTを実行した
* Attendanceテーブルに登録されるレーベルが、同じユーザーでも新規作成された
* Attendanceテーブルのidは新たに作成され、userIdはuserテーブルのidが入った
* 同じユーザーの同じ日にPOSTを飛ばした場合、はじかれてdbに登録されなかった

### postmanでGETを実行した
* GETのresponseのattendanceTimeは8:30のような形でなく、AttendanceテーブルのattendanceTimeと同じものが返された
* isAttendがfalseのときのattendanceTimeは1990-01-01T00:00:00.000Zが返された

