### PR TITLE
同じ日付の公欠は更新するよう修正

### DIFF
--- a/next_app/src/app/api/absence/route.ts
+++ b/next_app/src/app/api/absence/route.ts
@@ -1,22 +1,37 @@
 import prisma from "../../../lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
-import { absenceSchema, validateAbsence } from "@/schema";
+import { absenceSchema } from "@/schema";
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
   try {
     await absenceSchema.parseAsync(body);
 
-    const isValidAbsence = await validateAbsence(body.userId, body.absenceTime);
-    if (!isValidAbsence) {
-      return NextResponse.json({
-        ok: false,
-        error: "登録済みの公欠です",
+    // 同じ日付、同じユーザーの公欠データを検索
+    const datePart = body.absenceTime.slice(0, 10); // 'YYYY-MM-DD' 部分を取得
+    const minDate = new Date(datePart + "T00:00:00+09:00");
+    const maxDate = new Date(datePart + "T23:59:59+09:00");
+
+    const existingAbsence = await prisma.absence.findFirst({
+      where: {
+        userId: body.userId,
+        absenceTime: { gte: minDate, lte: maxDate },
+      },
+    });
+
+    if (existingAbsence) {
+      // 同じ日付の公欠がある場合更新
+      await prisma.absence.update({
+        where: { id: existingAbsence.id },
+        data: body,
       });
     }
-    await prisma.absence.create({
-      data: body,
-    });
+    // 同じ日付の公欠がない場合新規作成
+    else {
+      await prisma.absence.create({
+        data: body,
+      });
+    }
     return NextResponse.json({
       ok: true,
     });
@@ -24,5 +39,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error });
   }
 }
-
-

--- a/next_app/src/app/globals.css
+++ b/next_app/src/app/globals.css
@@ -25,6 +25,20 @@ textarea {
   font-family: "Noto Sans JP", sans-serif;
 }
 
+.date-input {
+  border-radius: 5px;
+  border: 1px #d3d3d3 solid;
+  padding: 4px 12px;
+  background-color: white;
+  height: 22px;
+  box-sizing: border-box;
+  box-shadow: none;
+}
+
+.date-input:focus {
+  outline: none;
+  border: 1.5px solid #030303;
+}
 
 
 @media (prefers-color-scheme: dark) {
@@ -52,5 +66,11 @@ textarea {
 
   .dark-mode-border {
     border-color: var(--dark-mode-border-color);
+  }
+
+  .date-input:focus {
+    outline: none;
+    border: 1.5px solid #000000;
+    box-shadow: 0px 0px 0px 1.5px rgb(255, 255, 255); 
   }
 }

--- a/next_app/src/schema/index.ts
+++ b/next_app/src/schema/index.ts
@@ -31,19 +31,6 @@ const absenceSchema = z.object({
 });
 export { absenceSchema };
 
-//同じ人が同じ日に公欠登録しないか検証
-async function validateAbsence(userId: string, absenceTime: string) {
-  //年月日が同じ、時間が違うものもはじく
-  const datePart = absenceTime.slice(0, 10); // 'YYYY-MM-DD' 部分を取得
-  const minDate = new Date(datePart + "T00:00:00+09:00");
-  const maxDate = new Date(datePart + "T23:59:59+09:00");
-
-  const absence = await prisma.absence.findFirst({
-    where: { userId: userId, absenceTime: { gte: minDate, lte: maxDate } },
-  });
-  return absence === null; //存在しないabsenceならtrue
-}
-export { validateAbsence };
 
 const changeTimeSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## やったこと

### api/absenceを修正した
* 同じユーザーが同じ日付に公欠を作成した場合公欠理由が上書きされるようにした
* 新しい日付に公欠を作成すると新規作成される

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 公欠理由を上書きできる

## できなくなること（ユーザ目線）

* なし

## 動作確認
### postmanで公欠をPOSTした
* 新しい日付に公欠を作成するとデータベースでレーベルが新規作成された
* 同じユーザーが同じ日付にPOSTするとデータベースですでに存在する公欠のレーベルが上書きされ、reasonが更新された
